### PR TITLE
Fix: Correct misleading test and bug in paragraph extraction

### DIFF
--- a/src/utils/content.test.ts
+++ b/src/utils/content.test.ts
@@ -114,6 +114,6 @@ No p tags here.`);
       data: {},
       body: '<p class="foo" id="bar">Paragraph with attributes.</p><p>Next one.</p>',
     };
-    expect(extractPreviewContent(post)).toBe('<p>Next one.</p>');
+    expect(extractPreviewContent(post)).toBe('<p class="foo" id="bar">Paragraph with attributes.</p>');
   });
 });

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -21,7 +21,7 @@ export function extractPreviewContent(post: Post): string {
   }
 
   if (post.body) {
-    const firstParagraphMatch = post.body.match(/<p>.*?<\/p>/s);
+    const firstParagraphMatch = post.body.match(/<p(?:\s+[^>]*)?>.*?<\/p>/is);
     if (firstParagraphMatch && firstParagraphMatch[0]) {
       return firstParagraphMatch[0];
     }


### PR DESCRIPTION
The test 'should correctly extract the first paragraph even with attributes on the p tag' in `src/utils/content.test.ts` had an incorrect assertion that expected the second paragraph in a test string, rather than the first paragraph with attributes as its name suggested. This effectively masked a bug.

This commit:
1. Corrects the assertion in the aforementioned test to accurately expect the first paragraph, including its attributes.
2. Fixes the `extractPreviewContent` function in `src/utils/content.ts` by updating its regex to `/<p(?:\s+[^>]*)?>.*?<\/p>/is`. This new regex robustly handles HTML `<p>` tags that may contain attributes, ensuring the first paragraph is correctly extracted.

With these changes, the test now accurately reflects the intended behavior and passes with the corrected function logic.