### PR TITLE
fix(admin): allow creating new series in post form

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,3 @@
+
+> blog@0.0.1 dev
+> astro dev

--- a/jules-scratch/verification/verify_series_creation.py
+++ b/jules-scratch/verification/verify_series_creation.py
@@ -1,0 +1,27 @@
+
+import asyncio
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.goto("http://localhost:4321/admin/posts/create")
+
+        # Fill in the title to enable the form
+        await page.locator("#title").fill("Test Post")
+
+        # Interact with the SeriesComponent
+        series_input = page.locator("#series")
+        await series_input.click()
+        await series_input.type("A New Series")
+        await page.keyboard.press("Enter")
+
+        # Verify the new series is selected
+        await expect(page.locator(".series-component-field .react-select__single-value")).to_have_text("A New Series")
+
+        await page.screenshot(path="jules-scratch/verification/verification.png")
+        await browser.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,8 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.0.tgz",
       "integrity": "sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.6.1",
@@ -277,6 +278,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -632,6 +634,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -655,6 +658,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2437,7 +2441,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2458,7 +2461,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2475,7 +2477,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2486,7 +2487,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2589,8 +2589,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2722,6 +2721,7 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
       "integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2730,6 +2730,7 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
       "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2807,6 +2808,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
       "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.1",
         "@typescript-eslint/types": "8.32.1",
@@ -3109,6 +3111,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.1.4.tgz",
       "integrity": "sha512-CFc2Bpb3sz4Sdt53kdNGq+qZKLftBwX4qZLC03CBUc0N1LJrOoL0ZeK0oq/708mtnpwccL0BZCY9d1WuiBSr7Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.1.4",
         "fflate": "^0.8.2",
@@ -3145,6 +3148,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3458,6 +3462,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.7.11.tgz",
       "integrity": "sha512-9qRVwp8pue3isddLBnTexJsmKFpmms9Fo7Ss+3yrC0aINvbHKpD7q6qf52BtfQEk2xJgyx3SQy3dUsuD90sEqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.11.0",
         "@astrojs/internal-helpers": "0.6.1",
@@ -4161,6 +4166,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -4977,8 +4983,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5308,6 +5313,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7738,7 +7744,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9485,6 +9490,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -9533,6 +9539,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9592,7 +9599,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9608,7 +9614,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9619,7 +9624,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9632,8 +9636,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -9726,6 +9729,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9734,6 +9738,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10256,6 +10261,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.2.tgz",
       "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -11727,6 +11733,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12180,6 +12187,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12295,6 +12303,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
       "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "3.1.4",
         "@vitest/mocker": "3.1.4",
@@ -12720,20 +12729,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -12787,6 +12782,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/admin/SeriesComponent.tsx
+++ b/src/components/admin/SeriesComponent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Select from "react-select";
+import CreatableSelect from "react-select/creatable"; // Use CreatableSelect
 import type { OnChangeValue } from "react-select";
 import {
   customReactSelectStyles,
@@ -9,7 +9,7 @@ import {
 interface SeriesComponentProps {
   id: string;
   label: string;
-  value: string | null | undefined; // Series is a single string or null/undefined
+  value: string | null | undefined;
   onChange: (newSeries: string | null) => void;
   suggestions?: string[];
   placeholder?: string;
@@ -26,20 +26,26 @@ const SeriesComponent: React.FC<SeriesComponentProps> = ({
   onBlur,
 }) => {
   const suggestionOptions: readonly SelectOption[] = suggestions.map((s) => ({
-    value: s, // Keep original casing for series display if desired, or .toLowerCase()
+    value: s,
     label: s,
   }));
 
-  // Find the SelectOption that matches the current string value
   const currentSeriesOption: SelectOption | null = value
     ? suggestionOptions.find((option) => option.value === value) || {
         value,
         label: value,
-      } // Fallback if not in suggestions
+      }
     : null;
 
   const handleChange = (newValue: OnChangeValue<SelectOption, false>) => {
     onChange(newValue ? newValue.value : null);
+  };
+
+  // Handle creation of a new series
+  const handleCreate = (inputValue: string) => {
+    const newSeriesValue = inputValue.trim();
+    if (!newSeriesValue) return;
+    onChange(newSeriesValue);
   };
 
   return (
@@ -47,16 +53,18 @@ const SeriesComponent: React.FC<SeriesComponentProps> = ({
       <label htmlFor={id} className="series-component-label">
         {label}
       </label>
-      <Select
+      <CreatableSelect // Use CreatableSelect component
         inputId={id}
         instanceId={id}
         options={suggestionOptions}
         value={currentSeriesOption}
         onChange={handleChange}
-        placeholder={placeholder || "Select or type a series..."}
+        onCreateOption={handleCreate} // Add onCreateOption handler
+        placeholder={placeholder || "Select or create a series..."}
         styles={customReactSelectStyles}
         onBlur={onBlur}
-        isClearable // Allow clearing the series
+        isClearable
+        formatCreateLabel={(inputValue) => `Create "${inputValue}"`} // Customize create label
       />
     </div>
   );


### PR DESCRIPTION
The SeriesComponent was using a standard `Select` component from `react-select`, which did not allow for the creation of new series. This was inconsistent with the `TagsComponent`, which used `CreatableSelect` to allow for the creation of new tags.

This commit updates the `SeriesComponent` to use `CreatableSelect`, enabling users to create new series directly from the post form. This improves the user experience and makes the series functionality consistent with the tags functionality.