### PR TITLE
Fix pre-push test failures

### DIFF
--- a/src/hooks/__tests__/useRAGQuery.test.ts
+++ b/src/hooks/__tests__/useRAGQuery.test.ts
@@ -13,40 +13,36 @@ describe("useRAGQuery", () => {
   it("should initialize with default state", () => {
     const { result } = renderHook(() => useRAGQuery());
 
-    expect(result.current.query).toBe("");
     expect(result.current.results).toEqual([]);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
+    expect(result.current.queryTime).toBe(0);
+    expect(typeof result.current.query).toBe("function");
+    expect(typeof result.current.clear).toBe("function");
   });
 
-  it("should update query when setQuery is called", () => {
-    const { result } = renderHook(() => useRAGQuery());
-
-    act(() => {
-      result.current.setQuery("test query");
-    });
-
-    expect(result.current.query).toBe("test query");
-  });
-
-  it("should fetch results when executeSearch is called", async () => {
+  it("should fetch results when query is called", async () => {
     const mockResults = [
-      { id: "1", content: "Test post", similarity: 0.9, type: "post" },
+      {
+        content: "Test post",
+        score: 0.9,
+        metadata: { slug: "test", title: "Test" },
+      },
     ];
 
-    (global.fetch as any).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ results: mockResults }),
-    });
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {
+        ok: true,
+        json: async () => ({
+          data: { results: mockResults, queryTime: 123, count: 1 },
+        }),
+      }
+    );
 
     const { result } = renderHook(() => useRAGQuery());
 
-    act(() => {
-      result.current.setQuery("test query");
-    });
-
     await act(async () => {
-      await result.current.executeSearch();
+      await result.current.query("test query");
     });
 
     await waitFor(() => {
@@ -54,22 +50,32 @@ describe("useRAGQuery", () => {
     });
 
     expect(result.current.results).toEqual(mockResults);
+    expect(result.current.queryTime).toBe(123);
     expect(result.current.error).toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith("/api/rag-query", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: "test query",
+        topK: 10,
+        filter: {
+          contentType: "all",
+        },
+      }),
+    });
   });
 
   it("should handle errors when fetch fails", async () => {
-    (global.fetch as any).mockRejectedValueOnce(
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error("Network error")
     );
 
     const { result } = renderHook(() => useRAGQuery());
 
-    act(() => {
-      result.current.setQuery("test query");
-    });
-
     await act(async () => {
-      await result.current.executeSearch();
+      await result.current.query("test query");
     });
 
     await waitFor(() => {
@@ -80,13 +86,88 @@ describe("useRAGQuery", () => {
     expect(result.current.results).toEqual([]);
   });
 
-  it("should not execute search when query is empty", async () => {
+  it("should not execute query when query text is empty", async () => {
     const { result } = renderHook(() => useRAGQuery());
 
     await act(async () => {
-      await result.current.executeSearch();
+      await result.current.query("");
     });
 
     expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.results).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should clear results when clear is called", async () => {
+    const mockResults = [
+      {
+        content: "Test post",
+        score: 0.9,
+        metadata: { slug: "test", title: "Test" },
+      },
+    ];
+
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {
+        ok: true,
+        json: async () => ({
+          data: { results: mockResults, queryTime: 123, count: 1 },
+        }),
+      }
+    );
+
+    const { result } = renderHook(() => useRAGQuery());
+
+    // First query to populate results
+    await act(async () => {
+      await result.current.query("test query");
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual(mockResults);
+    });
+
+    // Then clear
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.queryTime).toBe(0);
+  });
+
+  it("should support custom options", async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {
+        ok: true,
+        json: async () => ({
+          data: { results: [], queryTime: 0, count: 0 },
+        }),
+      }
+    );
+
+    const { result } = renderHook(() => useRAGQuery());
+
+    await act(async () => {
+      await result.current.query("test query", {
+        topK: 5,
+        contentType: "posts",
+      });
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/rag-query", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: "test query",
+        topK: 5,
+        filter: {
+          contentType: "posts",
+        },
+      }),
+    });
   });
 });


### PR DESCRIPTION
- Rewrote useAutoSave tests to match side-effect only hook API
- Rewrote useRAGQuery tests to match callback-based query API
- Fixed useSynthesisData tests to use correct method name (refetch vs refresh)
- Replaced 'any' types with proper TypeScript types to satisfy linting
- All 155 tests now passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)