### PR TITLE
Fix embedding dimension mismatch error

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,7 @@
 // @ts-check
+import { config } from "dotenv";
+config(); // Load .env file before any other imports
+
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
 import mdx from "@astrojs/mdx";


### PR DESCRIPTION
- Import and call dotenv.config() at top of astro.config.mjs
- Ensures OLLAMA_EMBEDDING_MODEL is available to ragConfig.ts
- Fixes dimension mismatch when dev server uses different model than CLI scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)