### PR TITLE
Fix failing pre-push tests

### DIFF
--- a/src/hooks/__tests__/useRAGQuery.test.ts
+++ b/src/hooks/__tests__/useRAGQuery.test.ts
@@ -34,7 +34,9 @@ describe("useRAGQuery", () => {
       {
         ok: true,
         json: async () => ({
-          data: { results: mockResults, queryTime: 123, count: 1 },
+          results: mockResults,
+          queryTime: 123,
+          count: 1,
         }),
       }
     );
@@ -111,7 +113,9 @@ describe("useRAGQuery", () => {
       {
         ok: true,
         json: async () => ({
-          data: { results: mockResults, queryTime: 123, count: 1 },
+          results: mockResults,
+          queryTime: 123,
+          count: 1,
         }),
       }
     );
@@ -142,7 +146,9 @@ describe("useRAGQuery", () => {
       {
         ok: true,
         json: async () => ({
-          data: { results: [], queryTime: 0, count: 0 },
+          results: [],
+          queryTime: 0,
+          count: 0,
         }),
       }
     );

--- a/src/hooks/__tests__/useSynthesisData.test.ts
+++ b/src/hooks/__tests__/useSynthesisData.test.ts
@@ -31,7 +31,7 @@ describe("useSynthesisData", () => {
     (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       {
         ok: true,
-        json: async () => ({ data: mockData }),
+        json: async () => mockData,
       }
     );
 
@@ -103,11 +103,11 @@ describe("useSynthesisData", () => {
     (global.fetch as unknown as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: mockData1 }),
+        json: async () => mockData1,
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ data: mockData2 }),
+        json: async () => mockData2,
       });
 
     const { result } = renderHook(() => useSynthesisData());


### PR DESCRIPTION
- Remove extra data wrapper in useRAGQuery test mocks
- Remove extra data wrapper in useSynthesisData test mocks
- API endpoints return data directly via createSuccessResponse

🤖 Generated with [Claude Code](https://claude.com/claude-code)