### PR TITLE
Fix RAG Index embedding configuration issues

### DIFF
--- a/src/components/admin/rag-search/IndexStats.tsx
+++ b/src/components/admin/rag-search/IndexStats.tsx
@@ -73,9 +73,7 @@ export default function IndexStats() {
                   <dt>Model:</dt>
                   <dd>{statsData.embeddingModel}</dd>
                   <dt>Dimensions:</dt>
-                  <dd>{statsData.embeddingDim}</dd>
-                  <dt>Version:</dt>
-                  <dd>{statsData.version}</dd>
+                  <dd>{statsData.embeddingDim}d</dd>
                 </dl>
               </div>
 

--- a/src/services/rag/embeddings.ts
+++ b/src/services/rag/embeddings.ts
@@ -11,6 +11,7 @@ import { ragConfig } from "../../ragConfig.js";
 
 export interface EmbeddingProvider {
   name: string;
+  modelName: string;
   dimensions: number;
   embed(texts: string[]): Promise<number[][]>;
   embedSingle(text: string): Promise<number[]>;
@@ -21,10 +22,16 @@ export interface EmbeddingProvider {
  */
 class TransformersEmbeddingProvider implements EmbeddingProvider {
   name = "transformers";
+  modelName: string;
   dimensions = 384;
-  private model = "Xenova/all-MiniLM-L6-v2";
+  private model: string;
   private embedder: Pipeline | null = null;
   private initPromise: Promise<void> | null = null;
+
+  constructor(model = ragConfig.transformers.model) {
+    this.model = model;
+    this.modelName = model;
+  }
 
   /**
    * Initialize the embedding model (lazy loading)
@@ -125,6 +132,7 @@ class TransformersEmbeddingProvider implements EmbeddingProvider {
  */
 class OllamaEmbeddingProvider implements EmbeddingProvider {
   name = "ollama";
+  modelName: string;
   dimensions = 0; // Will be auto-detected on first use
   private model: string;
   private baseUrl: string;
@@ -135,6 +143,7 @@ class OllamaEmbeddingProvider implements EmbeddingProvider {
   ) {
     this.baseUrl = baseUrl;
     this.model = model;
+    this.modelName = model;
   }
 
   /**

--- a/src/services/rag/index.ts
+++ b/src/services/rag/index.ts
@@ -99,7 +99,7 @@ export class RAGService {
       // Initialize storage
       this.storage = await createStorage(
         this.provider.dimensions,
-        this.provider.name
+        this.provider.modelName
       );
 
       // Verify provider compatibility with existing index (should match now)
@@ -476,12 +476,20 @@ export class RAGService {
         return null;
       }
 
+      // Get actual counts from database (more accurate than metadata)
+      const dbStats = await this.storage.getStats();
+
       return {
         version: metadata.version,
         embeddingModel: metadata.embeddingModel,
         embeddingDim: metadata.embeddingDim,
         provider: this.provider.name,
-        stats: metadata.stats,
+        stats: {
+          totalPosts: metadata.stats.totalPosts,
+          totalParagraphs: dbStats.postsCount, // Actual count from database
+          totalQuotes: dbStats.quotesCount, // Actual count from database
+          lastUpdated: metadata.lastUpdated,
+        },
       };
     } catch (error) {
       console.error("[RAG] Failed to get stats:", error);

--- a/src/services/rag/storage.ts
+++ b/src/services/rag/storage.ts
@@ -83,21 +83,33 @@ export class LanceDBStorage {
           },
         };
         await this.saveMetadata(metadata);
-      } else if (metadata.embeddingDim !== embeddingDim) {
-        // Special case: 0d means dimensions weren't detected during initial creation
-        if (metadata.embeddingDim === 0 && embeddingDim > 0) {
+      } else {
+        // Check if model name needs updating (dimensions match but model changed)
+        if (metadata.embeddingModel !== embeddingModel) {
           console.log(
-            `[RAG Storage] Updating metadata with detected dimensions: ${embeddingDim}d`
+            `[RAG Storage] Updating embedding model: ${metadata.embeddingModel} -> ${embeddingModel}`
           );
-          metadata.embeddingDim = embeddingDim;
           metadata.embeddingModel = embeddingModel;
           await this.saveMetadata(metadata);
-        } else {
-          // Metadata exists but dimensions don't match - log warning but don't overwrite
-          console.warn(
-            `[RAG Storage] Dimension mismatch: existing index has ${metadata.embeddingDim}d, ` +
-              `but initializing with ${embeddingDim}d. Keeping existing metadata.`
-          );
+        }
+
+        // Check for dimension mismatch
+        if (metadata.embeddingDim !== embeddingDim) {
+          // Special case: 0d means dimensions weren't detected during initial creation
+          if (metadata.embeddingDim === 0 && embeddingDim > 0) {
+            console.log(
+              `[RAG Storage] Updating metadata with detected dimensions: ${embeddingDim}d`
+            );
+            metadata.embeddingDim = embeddingDim;
+            metadata.embeddingModel = embeddingModel;
+            await this.saveMetadata(metadata);
+          } else {
+            // Metadata exists but dimensions don't match - log warning but don't overwrite
+            console.warn(
+              `[RAG Storage] Dimension mismatch: existing index has ${metadata.embeddingDim}d, ` +
+                `but initializing with ${embeddingDim}d. Keeping existing metadata.`
+            );
+          }
         }
       }
 


### PR DESCRIPTION
- Display actual embedding model name instead of provider type
- Show embedding dimensions with 'd' suffix for clarity
- Remove unhelpful version field from stats display
- Use real-time database counts for quotes/paragraphs instead of stale metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)