### PR TITLE
Collapse panels by default on edit page

### DIFF
--- a/src/components/admin/ai-assistant/AIAssistantPanel.tsx
+++ b/src/components/admin/ai-assistant/AIAssistantPanel.tsx
@@ -27,7 +27,7 @@ export const AIAssistantPanel: React.FC<AIAssistantPanelProps> = ({
   currentPost: currentPostProp,
   onInsertText, // eslint-disable-line @typescript-eslint/no-unused-vars
 }) => {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(true);
   const [prompts, setPrompts] = useState<Prompt[]>([]);
   const [selectedPromptId, setSelectedPromptId] = useState<string>("");
   const [customPrompt, setCustomPrompt] = useState("");


### PR DESCRIPTION
- Change AIAssistantPanel default state to collapsed
- TextAnalysisPanel already collapsed by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)